### PR TITLE
Bubble _generateChallengeToken timeout out of module

### DIFF
--- a/Query.js
+++ b/Query.js
@@ -15,7 +15,6 @@ class Query {
         this.sessionid = crypto.randomBytes(4) // a safe 32-bit integer
         this.full_stat = false;
         this.client = udp.createSocket('udp4');
-        console.log(obj.host);
 
         this.client.on('message', (data, info) => {
 


### PR DESCRIPTION
Example broken use case:
```javascript
const q = new Query({
    host: `${servers[req.params.server.toUpperCase()].IP}`,
    port: servers[req.params.server.toUpperCase()].PORT,
    timeout: 500
});

q.fullStat().then((response) => {
    res.json(response["online_players"]);
    q.close();
    return;
}).catch((err) => {
    res.json('0');
});
```

Expected behavior: Express returns 0
Current behavior: throws an error and exits
Change explanation: reject promise, then pass that rejection all the way back up, which lets Express handle it

Related to #1 