### PR TITLE
fix k/v indexing

### DIFF
--- a/Query.js
+++ b/Query.js
@@ -26,9 +26,7 @@ class Query {
 
             if (this.full_stat) {
                 var final = data.toString('utf-8', 11).split("\x00\x01player_\x00\x00"); // splicing the output as suggested
-                var kv = final[0].split("\0").filter((item) => {
-                    return item != "";
-                });
+                var kv = final[0].split("\0");
                 var players = final[1].split("\0").filter((item) => {
                     return item != "";
                 });


### PR DESCRIPTION
too much might get removed by the filter, throwing off later k/v pairs

example returned data:
```
plugins: 'map',
map: 'numplayers',
online_players: 'maxplayers',
max_players: 'hostport',
port: 'hostip',
```