### PR TITLE
Replace `on` with `once`

### DIFF
--- a/Query.js
+++ b/Query.js
@@ -81,7 +81,7 @@ class Query {
 
                 this.full_stat = true;
 
-                this.emitter.on('full_stat', (stat) => {
+                this.emitter.once('full_stat', (stat) => {
                     this.full_stat = false;
                     resolve(stat);
                 });
@@ -115,7 +115,7 @@ class Query {
                 buffer.writeInt32BE(token, 7);
                 this.basic_stat = true;
 
-                this.emitter.on('basic_stat', (stat) => {
+                this.emitter.once('basic_stat', (stat) => {
                     this.basic_stat = false;
                     resolve(stat);
                 });
@@ -154,7 +154,7 @@ class Query {
                         reject(err);
                     }
 
-                    this.emitter.on('challenge_token', (token) => {
+                    this.emitter.once('challenge_token', (token) => {
                         clearTimeout(timeout);
                         this.authenticating = false;
                         resolve(token);


### PR DESCRIPTION
**Bug:**

Memory leak when using using the same `Query` instance multiple times

**Reproduction:**

Run the following code:
```
const Query = require("minecraft-query");

async function test() {
    const q = new Query({host: '192.168.178.39', port: 25565, timeout: 7500});
    for(let i = 0; i < 20; i++) {
        const success = await q.fullStat();
        console.log(JSON.stringify(success))
    }
    q.close();
}
test()
```
**Expectation:**
After running the loop 20 times, all old listeners should be cleaned.

**Reality:**
When the above code is ran, Node emits the following warning:

```
(node:3424) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 challenge_token listeners added. Use emitter.setMaxListeners() to increase limit
(node:3424) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 full_stat listeners added. Use emitter.setMaxListeners() to increase limit
```

**Cause:**
This is caused because the code for this library is only using the `on` keyword to register listener, and it never calls `off` to unregister any listeners.

This means that every call to either `fullStats` or `basicStats` leaks 2 references to listeners

**Fix:**
This PR modifies the calls, so it calls `once` instead of `on`, these calls are special in the way that the only run "once", this means the listeners are automatically unregistered after 1 call